### PR TITLE
Show N/A when traffic or backlink data is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Setzen Sie vor dem Start folgende Umgebungsvariablen, falls verfügbar:
 * `SIMILARWEB_API_KEY` – Traffic-Abfrage
 * `OPR_API_KEY` – Backlink-Abfrage über [Open Page Rank](https://www.openpagerank.com/)
 
-Sind keine API-Schlüssel gesetzt, werden für die jeweiligen Felder `None` zurückgegeben.
+Sind keine API-Schlüssel gesetzt oder sind keine Daten verfügbar, werden für die jeweiligen Felder `N/A` zurückgegeben.

--- a/app.py
+++ b/app.py
@@ -16,9 +16,9 @@ if uploaded_file:
     total = len(df)
     for idx, domain in enumerate(df["domain"], start=1):
         status_placeholder.text(f"Checking {idx}/{total}: {domain}")
-        available = check_availability(domain)
         traffic = get_traffic(domain)
         backlinks = get_backlinks(domain)
+        available = check_availability(domain)
         results.append({
             "domain": domain,
             "available": available,
@@ -26,7 +26,7 @@ if uploaded_file:
             "backlinks": backlinks,
         })
         progress.progress(idx / total)
-    result_df = pd.DataFrame(results)
+    result_df = pd.DataFrame(results).fillna("N/A")
     st.dataframe(result_df)
     csv = result_df.to_csv(index=False).encode("utf-8")
     st.download_button("Download Results CSV", data=csv, file_name="domain_results.csv", mime="text/csv")

--- a/domain_utils.py
+++ b/domain_utils.py
@@ -12,7 +12,7 @@ def check_availability(domain):
 def get_traffic(domain):
     api_key = os.getenv("SIMILARWEB_API_KEY")
     if not api_key:
-        return None
+        return "N/A"
     url = f"https://api.similarweb.com/v1/website/{domain}/traffic-and-engagement/visits?api_key={api_key}&country=world"
     try:
         r = requests.get(url, timeout=10)
@@ -21,14 +21,14 @@ def get_traffic(domain):
         visits = data.get("visits")
         if isinstance(visits, dict):
             return sum(visits.values())
-        return None
+        return "N/A"
     except Exception:
-        return None
+        return "N/A"
 
 def get_backlinks(domain):
     api_key = os.getenv("OPR_API_KEY")
     if not api_key:
-        return None
+        return "N/A"
     url = f"https://openpagerank.com/api/v1.0/getPageRank?domains%5B0%5D={domain}"
     headers = {"API-OPR": api_key}
     try:
@@ -38,6 +38,6 @@ def get_backlinks(domain):
         response = data.get("response", [])
         if response:
             return response[0].get("referring_domains")
-        return None
+        return "N/A"
     except Exception:
-        return None
+        return "N/A"


### PR DESCRIPTION
## Summary
- Return `N/A` for missing traffic or backlink metrics so CSV outputs include a clear placeholder
- Always query traffic/backlink metrics for each domain before checking availability and fill empty cells with `N/A`
- Document `N/A` behavior in README

## Testing
- `python -m py_compile app.py domain_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0fde7cdb8832b88cd13395a2196da