### PR TITLE
Add fallback traffic and backlink sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,17 @@ Backlinks auf sie verweisen.
 4. Warten Sie, bis alle Domains geprüft wurden. Der Fortschritt wird angezeigt.
 5. Laden Sie das Ergebnis als CSV-Datei herunter.
 
-## API-Keys
+## API-Keys und Fallbacks
 
-Für die Abfragen von Traffic und Backlinks werden API-Schlüssel erwartet.
-Setzen Sie vor dem Start folgende Umgebungsvariablen, falls verfügbar:
+Für die Abfragen von Traffic und Backlinks werden nach Möglichkeit
+API-Schlüssel verwendet. Setzen Sie vor dem Start folgende
+Umgebungsvariablen, falls verfügbar:
 
-* `SIMILARWEB_API_KEY` – Traffic-Abfrage
+* `SIMILARWEB_API_KEY` – Traffic-Abfrage über die SimilarWeb-API
 * `OPR_API_KEY` – Backlink-Abfrage über [Open Page Rank](https://www.openpagerank.com/)
 
-Sind keine API-Schlüssel gesetzt oder sind keine Daten verfügbar, werden für die jeweiligen Felder `N/A` zurückgegeben.
+Sind keine API-Schlüssel gesetzt oder liefern die APIs keine Daten,
+versucht das Programm, alternative öffentliche Quellen zu nutzen
+(`data.similarweb.com` für Traffic bzw. `api.openlinkprofiler.org` für
+Backlinks). Erst wenn auch diese Abfragen fehlschlagen, wird für die
+jeweiligen Felder `N/A` zurückgegeben.

--- a/domain_utils.py
+++ b/domain_utils.py
@@ -10,34 +10,82 @@ def check_availability(domain):
         return True
 
 def get_traffic(domain):
+    """Return estimated visits for *domain*.
+
+    Versucht zunächst, die SimilarWeb-API mit einem API-Key zu nutzen. Sollte kein
+    Schlüssel vorhanden sein oder die Abfrage fehlschlagen, wird als Fallback
+    die öffentliche SimilarWeb-Datenquelle verwendet. Führen beide Versuche zu
+    keinem Ergebnis, wird ``"N/A"`` zurückgegeben.
+    """
+
     api_key = os.getenv("SIMILARWEB_API_KEY")
-    if not api_key:
-        return "N/A"
-    url = f"https://api.similarweb.com/v1/website/{domain}/traffic-and-engagement/visits?api_key={api_key}&country=world"
+    if api_key:
+        url = (
+            f"https://api.similarweb.com/v1/website/{domain}/traffic-and-engagement/visits"
+            f"?api_key={api_key}&country=world"
+        )
+        try:
+            r = requests.get(url, timeout=10)
+            r.raise_for_status()
+            data = r.json()
+            visits = data.get("visits")
+            if isinstance(visits, dict):
+                return sum(visits.values())
+        except Exception:
+            pass
+
+    fallback_url = f"https://data.similarweb.com/api/v1/data?domain={domain}"
     try:
-        r = requests.get(url, timeout=10)
+        r = requests.get(fallback_url, timeout=10)
         r.raise_for_status()
         data = r.json()
-        visits = data.get("visits")
+        visits = data.get("EstimatedMonthlyVisits")
         if isinstance(visits, dict):
             return sum(visits.values())
-        return "N/A"
     except Exception:
-        return "N/A"
+        pass
+    return "N/A"
 
 def get_backlinks(domain):
+    """Return number of referring domains for *domain*.
+
+    Primär wird die Open-Page-Rank-API verwendet. Fehlt der API-Key oder ist
+    keine Antwort verfügbar, greift die Funktion auf die offene
+    OpenLinkProfiler-API zurück.
+    """
+
     api_key = os.getenv("OPR_API_KEY")
-    if not api_key:
-        return "N/A"
-    url = f"https://openpagerank.com/api/v1.0/getPageRank?domains%5B0%5D={domain}"
-    headers = {"API-OPR": api_key}
+    if api_key:
+        url = (
+            f"https://openpagerank.com/api/v1.0/getPageRank?domains%5B0%5D={domain}"
+        )
+        headers = {"API-OPR": api_key}
+        try:
+            r = requests.get(url, headers=headers, timeout=10)
+            r.raise_for_status()
+            data = r.json()
+            response = data.get("response", [])
+            if response:
+                referring = response[0].get("referring_domains")
+                if referring is not None:
+                    return referring
+        except Exception:
+            pass
+
+    fallback_url = (
+        f"https://api.openlinkprofiler.org/summary?domain={domain}&format=json"
+    )
     try:
-        r = requests.get(url, headers=headers, timeout=10)
+        r = requests.get(fallback_url, timeout=10)
         r.raise_for_status()
         data = r.json()
-        response = data.get("response", [])
-        if response:
-            return response[0].get("referring_domains")
-        return "N/A"
+        backlinks = (
+            data.get("summary", {}).get("backlinks")
+            or data.get("response", {}).get("summary", {}).get("backlinks")
+            or data.get("backlinks")
+        )
+        if backlinks is not None:
+            return backlinks
     except Exception:
-        return "N/A"
+        pass
+    return "N/A"


### PR DESCRIPTION
## Summary
- query SimilarWeb API when key provided, otherwise use public SimilarWeb dataset
- try Open Page Rank for backlinks, falling back to OpenLinkProfiler when necessary
- document new data source fallbacks in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py domain_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b100db8f58832b8f7abfda299a91ce