### PR TITLE
Add logging for traffic and backlink retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ versucht das Programm, alternative öffentliche Quellen zu nutzen
 (`data.similarweb.com` für Traffic bzw. `api.openlinkprofiler.org` für
 Backlinks). Erst wenn auch diese Abfragen fehlschlagen, wird für die
 jeweiligen Felder `N/A` zurückgegeben.
+
+## Logging
+
+Während der Verarbeitung schreibt die Anwendung Status- und Fehlermeldungen
+in die Datei `domain_checker.log`. Anhand dieser Logdatei lässt sich
+nachvollziehen, welche API-Aufrufe erfolgreich waren und wo eventuell
+Probleme auftraten.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,11 @@
 import streamlit as st
 import pandas as pd
-from domain_utils import check_availability, get_traffic, get_backlinks
+from domain_utils import (
+    check_availability,
+    get_traffic,
+    get_backlinks,
+    logger,
+)
 
 st.title("Domain Checker 2.0")
 
@@ -19,6 +24,13 @@ if uploaded_file:
         traffic = get_traffic(domain)
         backlinks = get_backlinks(domain)
         available = check_availability(domain)
+        logger.info(
+            "Finished %s: available=%s, traffic=%s, backlinks=%s",
+            domain,
+            available,
+            traffic,
+            backlinks,
+        )
         results.append({
             "domain": domain,
             "available": available,
@@ -30,3 +42,4 @@ if uploaded_file:
     st.dataframe(result_df)
     csv = result_df.to_csv(index=False).encode("utf-8")
     st.download_button("Download Results CSV", data=csv, file_name="domain_results.csv", mime="text/csv")
+    logger.info("Completed processing %d domains", total)

--- a/domain_utils.py
+++ b/domain_utils.py
@@ -1,12 +1,25 @@
 import whois
 import requests
 import os
+import logging
+
+# Configure a basic logger that writes to ``domain_checker.log``.
+logger = logging.getLogger("domain_checker")
+if not logger.handlers:
+    logger.setLevel(logging.INFO)
+    handler = logging.FileHandler("domain_checker.log")
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
 def check_availability(domain):
     try:
         w = whois.whois(domain)
-        return w.domain_name is None
-    except Exception:
+        available = w.domain_name is None
+        logger.info("Checked availability for %s: %s", domain, available)
+        return available
+    except Exception as e:
+        logger.exception("Error checking availability for %s: %s", domain, e)
         return True
 
 def get_traffic(domain):
@@ -26,24 +39,37 @@ def get_traffic(domain):
         )
         try:
             r = requests.get(url, timeout=10)
+            logger.info("SimilarWeb API response for %s: %s", domain, r.status_code)
             r.raise_for_status()
             data = r.json()
             visits = data.get("visits")
             if isinstance(visits, dict):
-                return sum(visits.values())
-        except Exception:
-            pass
+                total = sum(visits.values())
+                logger.info("Fetched traffic for %s: %s", domain, total)
+                return total
+        except Exception as e:
+            logger.exception(
+                "Error fetching traffic for %s via SimilarWeb API: %s", domain, e
+            )
 
     fallback_url = f"https://data.similarweb.com/api/v1/data?domain={domain}"
     try:
         r = requests.get(fallback_url, timeout=10)
+        logger.info(
+            "SimilarWeb public API response for %s: %s", domain, r.status_code
+        )
         r.raise_for_status()
         data = r.json()
         visits = data.get("EstimatedMonthlyVisits")
         if isinstance(visits, dict):
-            return sum(visits.values())
-    except Exception:
-        pass
+            total = sum(visits.values())
+            logger.info("Fetched traffic for %s via fallback: %s", domain, total)
+            return total
+    except Exception as e:
+        logger.exception(
+            "Error fetching traffic for %s via public SimilarWeb API: %s", domain, e
+        )
+    logger.info("Returning 'N/A' for traffic of %s", domain)
     return "N/A"
 
 def get_backlinks(domain):
@@ -62,21 +88,28 @@ def get_backlinks(domain):
         headers = {"API-OPR": api_key}
         try:
             r = requests.get(url, headers=headers, timeout=10)
+            logger.info("Open Page Rank response for %s: %s", domain, r.status_code)
             r.raise_for_status()
             data = r.json()
             response = data.get("response", [])
             if response:
                 referring = response[0].get("referring_domains")
                 if referring is not None:
+                    logger.info("Fetched backlinks for %s: %s", domain, referring)
                     return referring
-        except Exception:
-            pass
+        except Exception as e:
+            logger.exception(
+                "Error fetching backlinks for %s via Open Page Rank: %s", domain, e
+            )
 
     fallback_url = (
         f"https://api.openlinkprofiler.org/summary?domain={domain}&format=json"
     )
     try:
         r = requests.get(fallback_url, timeout=10)
+        logger.info(
+            "OpenLinkProfiler response for %s: %s", domain, r.status_code
+        )
         r.raise_for_status()
         data = r.json()
         backlinks = (
@@ -85,7 +118,13 @@ def get_backlinks(domain):
             or data.get("backlinks")
         )
         if backlinks is not None:
+            logger.info(
+                "Fetched backlinks for %s via fallback: %s", domain, backlinks
+            )
             return backlinks
-    except Exception:
-        pass
+    except Exception as e:
+        logger.exception(
+            "Error fetching backlinks for %s via OpenLinkProfiler: %s", domain, e
+        )
+    logger.info("Returning 'N/A' for backlinks of %s", domain)
     return "N/A"


### PR DESCRIPTION
## Summary
- configure a shared logger writing to `domain_checker.log`
- log API responses and errors in traffic/backlink helpers
- record domain results and summary during CSV processing

## Testing
- `python -m py_compile app.py domain_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b10206c494832bb997cbf8400f1463