### PR TITLE
Scrape traffic and backlinks without API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,21 +12,13 @@ Backlinks auf sie verweisen.
 4. Warten Sie, bis alle Domains geprüft wurden. Der Fortschritt wird angezeigt.
 5. Laden Sie das Ergebnis als CSV-Datei herunter.
 
-## API-Keys und Fallbacks
+## Datenquellen
 
-Für die Abfragen von Traffic und Backlinks werden nach Möglichkeit
-API-Schlüssel verwendet. Sie sind optional – ohne Schlüssel
-erhalten Sie gegebenenfalls `N/A` als Ergebnis. Setzen Sie vor dem
-Start folgende Umgebungsvariablen, falls verfügbar:
-
-* `SIMILARWEB_API_KEY` – Traffic-Abfrage über die SimilarWeb-API
-* `OPR_API_KEY` – Backlink-Abfrage über [Open Page Rank](https://www.openpagerank.com/)
-
-Sind keine API-Schlüssel gesetzt oder liefern die APIs keine Daten,
-versucht das Programm, alternative öffentliche Quellen zu nutzen
-(`data.similarweb.com` für Traffic bzw. `api.openlinkprofiler.org` für
-Backlinks). Erst wenn auch diese Abfragen fehlschlagen, wird für die
-jeweiligen Felder `N/A` zurückgegeben.
+Traffic- und Backlinkwerte werden automatisch aus frei zugänglichen
+Webseiten ermittelt – es sind keine API-Schlüssel notwendig. Für jede
+Domain wird die entsprechende SimilarWeb- und OpenLinkProfiler-Seite
+abgerufen und der dort angezeigte Wert ausgelesen. Kann ein Wert nicht
+ermittelt werden, erscheint `N/A`.
 
 ## Logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 pandas
 python-whois
 requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- Gather monthly traffic by scraping SimilarWeb pages directly
- Extract backlink counts from OpenLinkProfiler without API keys
- Document new data sources and add BeautifulSoup dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile domain_utils.py app.py`
- `python - <<'PY'
from domain_utils import get_traffic, get_backlinks
print('traffic', get_traffic('example.com'))
print('backlinks', get_backlinks('example.com'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b106454e8c832ba35ef27fe88cb2f1