### PR TITLE
Use cloudscraper for traffic and backlink lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Backlinks auf sie verweisen.
 Traffic- und Backlinkwerte werden automatisch aus frei zugänglichen
 Webseiten ermittelt – es sind keine API-Schlüssel notwendig. Für jede
 Domain wird die entsprechende SimilarWeb- und OpenLinkProfiler-Seite
-abgerufen und der dort angezeigte Wert ausgelesen. Kann ein Wert nicht
+über [cloudscraper](https://pypi.org/project/cloudscraper/) abgerufen
+und der dort angezeigte Wert ausgelesen. Kann ein Wert nicht
 ermittelt werden, erscheint `N/A`.
 
 ## Logging

--- a/domain_utils.py
+++ b/domain_utils.py
@@ -4,6 +4,7 @@ import re
 
 import requests
 import whois
+import cloudscraper
 from bs4 import BeautifulSoup
 from whois.parser import PywhoisError
 
@@ -64,7 +65,8 @@ def get_traffic(domain):
     url = f"https://www.similarweb.com/website/{domain}/"
     headers = {"User-Agent": "Mozilla/5.0"}
     try:
-        r = requests.get(url, headers=headers, timeout=10)
+        scraper = cloudscraper.create_scraper()
+        r = scraper.get(url, headers=headers, timeout=10)
         logger.info("SimilarWeb HTML response for %s: %s", domain, r.status_code)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")
@@ -95,7 +97,8 @@ def get_backlinks(domain):
     url = f"https://openlinkprofiler.org/r/{domain}"
     headers = {"User-Agent": "Mozilla/5.0"}
     try:
-        r = requests.get(url, headers=headers, timeout=10)
+        scraper = cloudscraper.create_scraper()
+        r = scraper.get(url, headers=headers, timeout=10)
         logger.info("OpenLinkProfiler HTML response for %s: %s", domain, r.status_code)
         r.raise_for_status()
         soup = BeautifulSoup(r.text, "html.parser")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 python-whois
 requests
 beautifulsoup4
+cloudscraper


### PR DESCRIPTION
## Summary
- switch SimilarWeb and OpenLinkProfiler requests to cloudscraper
- add cloudscraper dependency
- document scraping approach

## Testing
- `python -m py_compile domain_utils.py`
- `python - <<'PY'
from domain_utils import get_traffic, get_backlinks
print('traffic:', get_traffic('nike.de'))
print('backlinks:', get_backlinks('nike.de'))
PY` *(returns N/A due to network restrictions)*
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68b107feea08832bb974221478660fab