### PR TITLE
Use Common Crawl and RDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ example.org
 
 ## Datenquellen
 
-Traffic- und Backlinkwerte werden automatisch aus frei zugänglichen
-Webseiten ermittelt – es sind keine API-Schlüssel notwendig. Für jede
-Domain wird die entsprechende SimilarWeb- und OpenLinkProfiler-Seite
-über [cloudscraper](https://pypi.org/project/cloudscraper/) abgerufen
-und der dort angezeigte Wert ausgelesen. Kann ein Wert nicht
-ermittelt werden, erscheint `N/A`.
+- **Traffic**: Anzahl der in der aktuellen [Common Crawl](https://commoncrawl.org) enthaltenen Seiten des jeweiligen Hosts.
+- **Backlinks**: Anzahl verweisender Domains aus dem öffentlichen [Common Crawl Web Graph](https://webgraph.cc).
+- **Verfügbarkeit**: Abfrage der [RDAP](https://datatracker.ietf.org/doc/html/rfc9083)-Schnittstelle.
+
+Für alle Anfragen sind keine API-Schlüssel nötig. Kann ein Wert nicht ermittelt
+werden, erscheint `N/A`.
 
 ## Logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 streamlit
 pandas
-python-whois
-beautifulsoup4
-cloudscraper
+requests


### PR DESCRIPTION
## Summary
- Replace SimilarWeb and OpenLinkProfiler scraping with Common Crawl and Web Graph APIs
- Use RDAP for domain availability checks
- Update documentation and dependencies

## Testing
- `python -m py_compile domain_utils.py app.py`
- `pip install -r requirements.txt`
- `python - <<'PY'
from domain_utils import get_traffic, get_backlinks, check_availability
print('traffic:', get_traffic('example.com'))
print('backlinks:', get_backlinks('example.com'))
print('availability:', check_availability('example.com'))
PY` *(fails: traffic/backlinks N/A, availability None due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b10b10ca28832b9e1023429de9e092