### PR TITLE
Restore whois availability check and add headless scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Backlinks auf sie verweisen.
 ## Nutzung
 
 1. Erstellen Sie eine CSV-Datei mit einer Domain pro Zeile. Optional kann die erste Zeile eine Kopfzeile `domain` enthalten.
-2. Doppelklicken Sie unter Windows auf `start.bat`.
+2. Doppelklicken Sie unter Windows auf `start.bat`. Beim ersten Start lädt
+   Playwright einen Browser herunter.
 3. Laden Sie die CSV-Datei über die Benutzeroberfläche hoch.
 4. Warten Sie, bis alle Domains geprüft wurden. Der Fortschritt wird angezeigt.
 5. Laden Sie das Ergebnis als CSV-Datei herunter.
@@ -34,12 +35,15 @@ example.org
 
 ## Datenquellen
 
-- **Traffic**: Anzahl der in der aktuellen [Common Crawl](https://commoncrawl.org) enthaltenen Seiten des jeweiligen Hosts.
-- **Backlinks**: Anzahl verweisender Domains aus dem öffentlichen [Common Crawl Web Graph](https://webgraph.cc).
-- **Verfügbarkeit**: Abfrage der [RDAP](https://datatracker.ietf.org/doc/html/rfc9083)-Schnittstelle.
+- **Traffic**: Scraping der öffentlichen SimilarWeb-Seite mit einem Headless-
+  Browser (Playwright).
+- **Backlinks**: Scraping der öffentlichen Daten auf OpenLinkProfiler mit
+  Playwright.
+- **Verfügbarkeit**: Whois-Abfrage über das Python-Paket `python-whois`.
 
-Für alle Anfragen sind keine API-Schlüssel nötig. Kann ein Wert nicht ermittelt
-werden, erscheint `N/A`.
+Für alle Anfragen sind keine API-Schlüssel nötig. Da die Seiten JavaScript
+verwenden, wird beim ersten Start automatisch der Playwright-Browser
+installiert. Kann ein Wert nicht ermittelt werden, erscheint `N/A`.
 
 ## Logging
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 streamlit
 pandas
 requests
+python-whois
+beautifulsoup4
+playwright

--- a/start.bat
+++ b/start.bat
@@ -3,4 +3,5 @@ python -m venv venv
 call venv\Scripts\activate
 pip install --upgrade pip
 pip install -r requirements.txt
+playwright install
 streamlit run app.py


### PR DESCRIPTION
## Summary
- Revert availability lookup to `python-whois`
- Use Playwright headless browser to scrape SimilarWeb and OpenLinkProfiler for traffic and backlinks
- Document new data sources and install Playwright in start script/requirements

## Testing
- `pip install -r requirements.txt`
- `playwright install chromium` *(fails: Host system missing dependencies but browser downloaded)*
- `python -m py_compile app.py domain_utils.py`
- `python - <<'PY'
from domain_utils import check_availability
print('example.com:', check_availability('example.com'))
print('dsadhjksdhasddm82.de:', check_availability('dsadhjksdhasddm82.de'))
PY` *(partial: example.com unavailable due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68b110112bac832bad2b4e98266f40f9