### PR TITLE
Use multiple free sources for traffic and backlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ example.org
 
 ## Datenquellen
 
-- **Traffic**: Scraping der öffentlichen SimilarWeb-Seite über eine einfache HTTP-Anfrage.
-- **Backlinks**: Scraping der öffentlichen Daten auf OpenLinkProfiler per HTTP-Anfrage.
+- **Traffic**: Scraping der Seite [StatsCrop](https://www.statscrop.com/) mit Fallback auf [Hypestat](https://hypestat.com/) und Auslesen der dort angegebenen "Daily Visitors" (hochgerechnet auf den Monat).
+- **Backlinks**: Abfrage der freien API von [HackerTarget](https://api.hackertarget.com/backlinks/) mit Fallback auf [OpenLinkProfiler](https://www.openlinkprofiler.org/) und Zählen der zurückgegebenen Links.
 - **Verfügbarkeit**: Whois-Abfrage über das Python-Paket `python-whois`.
 
-Für alle Anfragen sind keine API-Schlüssel nötig. Kann ein Wert nicht ermittelt werden, erscheint `N/A`.
+Für alle Anfragen sind keine API-Schlüssel nötig. Kann kein Wert ermittelt werden, wird `0` zurückgegeben.
 
 ## Logging
 


### PR DESCRIPTION
## Summary
- Attempt traffic lookup via StatsCrop with Hypestat fallback and return 0 if unavailable
- Count backlinks through HackerTarget with OpenLinkProfiler fallback
- Document new fallbacks and numeric defaults

## Testing
- `python -m py_compile domain_utils.py app.py`
- `python - <<'PY'
from domain_utils import get_traffic, get_backlinks
print('traffic:', get_traffic('example.com'))
print('backlinks:', get_backlinks('example.com'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b112be1850832ba61b28d500f06ea4